### PR TITLE
Add proper syntax highlighting through .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.p linguist-language="Pascal"
-*.inc linguist-language="Pascal"
+*.p linguist-language=Pascal
+*.inc linguist-language=Pascal

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.p linguist-language="Pascal"
+*.inc linguist-language="Pascal"


### PR DESCRIPTION
The Pascal source code in this repository is not highlighted correctly, this is because Linguist does not recognize the `.p` and `.inc` file extension for Pascal code. I addressed this with this PR by manually overriding Linguist to force it to highlight these files. You can take a look through my fork to see what it looks like. 